### PR TITLE
Incluír librería necesaria para uso de campos de perfil personalizados

### DIFF
--- a/message_output_appcrue.php
+++ b/message_output_appcrue.php
@@ -29,6 +29,7 @@ defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot.'/message/output/lib.php');
 require_once($CFG->dirroot.'/lib/filelib.php');
+require_once($CFG->dirroot.'/user/profile/lib.php');
 
 class message_output_appcrue extends \message_output {
 

--- a/version.php
+++ b/version.php
@@ -28,8 +28,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'message_appcrue';
-$plugin->release = '0.2.10';
-$plugin->version = 2022090200;
+$plugin->release = '0.2.11';
+$plugin->version = 2022101100;
 $plugin->requires = 2015111600;
 $plugin->maturity = MATURITY_STABLE;
 $plugin->dependencies = [


### PR DESCRIPTION
En caso de configurar el plugin para utilizar un campo del perfil de usuario personalizado es necesario incluír la librería: /user/profile/lib.php  para poder llamar a la función "profile_load_data()". 
En otro caso devuelve mensaje: "Adhoc task failed: mod_forum\task\send_user_notifications,Call to undefined function profile_load_data()"